### PR TITLE
MT download data - daily > fix repo

### DIFF
--- a/.github/workflows/mt-download-data-daily.yml
+++ b/.github/workflows/mt-download-data-daily.yml
@@ -13,11 +13,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: MT trigger download data workflow
-        run: gh workflow run mt-download-data.yml --repo mtransitapps/ca-ottawa-oc-transpo-bus-android
-        env:
-          GH_TOKEN: ${{ secrets.MT_PAT }}
-
-      - name: MT trigger download data workflow (ca-ottawa-oc-transpo-train-android)
-        run: gh workflow run mt-download-data.yml --repo mtransitapps/ca-ottawa-oc-transpo-train-android
+        run: gh workflow run mt-download-data.yml --repo ${{ github.repository }}
         env:
           GH_TOKEN: ${{ secrets.MT_PAT }}


### PR DESCRIPTION
Updated the workflow to use the current repository context and removed the redundant step for the train app.

Following:
- #7
- #9